### PR TITLE
Change the structure of the relation resolver

### DIFF
--- a/src/ObjectTypeComposer.ts
+++ b/src/ObjectTypeComposer.ts
@@ -1884,9 +1884,8 @@ export class ObjectTypeComposer<TSource = any, TContext = any> {
       return catchErrors
         ? Promise.resolve(payload).catch((e) => {
             // eslint-disable-next-line
-            console.log(`GQC ERROR: relation for ${this.getTypeName()}.${fieldName} throws error:`);
-            console.log(e); // eslint-disable-line
-            return null;
+            console.log(`GQC ERROR: relation for ${this.getTypeName()}.${fieldName} throws error: ${e.message}`);
+            throw e;
           })
         : payload;
     };


### PR DESCRIPTION
Change of the structure of the relation resolver to raise errors of nested relations following my question opened recently : https://github.com/graphql-compose/graphql-compose/issues/384

With this change, any exception raised by one of the nested relation (upon beforeQuery, for instance) will raise the exception at the upper level.